### PR TITLE
Fix reified minRandomCached()

### DIFF
--- a/src/main/java/nl/wykorijnsburger/kminrandom/MinRandomCached.kt
+++ b/src/main/java/nl/wykorijnsburger/kminrandom/MinRandomCached.kt
@@ -22,9 +22,7 @@ public fun <T : Any> KClass<T>.minRandomCached(): T = generateMinRandomCached(th
  * See [Kotlin 1.3.40 release notes (Accessing the reified type using reflection on JVM)](https://blog.jetbrains.com/kotlin/2019/06/kotlin-1-3-40-released/) for more details.
  */
 @OptIn(ExperimentalStdlibApi::class)
-public inline fun <reified T> minRandomCached(): T {
-    return typeOf<T>().jvmErasure.minRandom() as T
-}
+public inline fun <reified T> minRandomCached(): T = typeOf<T>().jvmErasure.minRandomCached() as T
 
 /**
  * Generates a minimal random instance of the supplied KClass

--- a/src/test/java/nl/wykorijnsburger/kminrandom/MinRandomCachedTest.kt
+++ b/src/test/java/nl/wykorijnsburger/kminrandom/MinRandomCachedTest.kt
@@ -18,4 +18,13 @@ internal class MinRandomCachedTest {
             assertThat(minRandomCached).isEqualTo(newMinRandom)
         }
     }
+
+    @Test
+    fun `Should cache random instance when using the reified minRandomCached method`() {
+        val newMinRandom = minRandomCached<SampleDC>()
+        repeat(10) {
+            val minRandomCached = minRandomCached<SampleDC>()
+            assertThat(minRandomCached).isEqualTo(newMinRandom)
+        }
+    }
 }


### PR DESCRIPTION
The reified variant of `minRandomCached()` was calling the non-cached method. This breaks the caching.